### PR TITLE
Add error alert on user deletion failure

### DIFF
--- a/usuarios.html
+++ b/usuarios.html
@@ -213,6 +213,7 @@ $(document).ready(function(){
                 cargarUsuarios();
             },
             error: function(xhr, status, error) {
+                alert('El borrado ha fallado. Contacte con el administrador de la aplicación.');
                 console.error('Error al eliminar el usuario:', error);
             }
         });


### PR DESCRIPTION
## Summary
- show an alert if the user deletion AJAX call fails so the user knows it was not deleted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f61ccbb1083268a71f29a21d6e114