### PR TITLE
Fix error handling for reservation cancel

### DIFF
--- a/reservas.html
+++ b/reservas.html
@@ -623,7 +623,9 @@
 					});
 				},
                 error: function(xhr, status, error) {
-                    console.error('Error al eliminar la reserva:', error);
+                    const msg = (xhr.responseJSON && xhr.responseJSON.message) ? xhr.responseJSON.message : 'Error al cancelar la reserva';
+                    alert(msg);
+                    console.error('Error al eliminar la reserva:', msg);
                 }
             });
             


### PR DESCRIPTION
## Summary
- show an alert with the API error message when cancelling a reservation fails

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f6f59193883268356d30e800988eb