### PR TITLE
Add player management page

### DIFF
--- a/jugadoresManagement.html
+++ b/jugadoresManagement.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+<title>Gestión de Jugadores</title>
+</head>
+<body>
+
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-1 wp-block-columns-is-layout-flex">
+    <div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:10%"></div>
+
+    <div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:80%">
+        <div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:10%"></div>
+        <div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:80%">
+
+            <!-- Formulario para añadir nuevo jugador -->
+            <form id="form-nuevo-jugador">
+                <center><h2>Gestión de Jugadores</h2></center>
+                <h3><label>Nombre del Jugador</label></h3><br>
+                <input type="text" id="nombreJugador" name="nombreJugador" required><br>
+                <h3><label>Puntos</label></h3><br>
+                <input type="number" step="0.01" id="puntosJugador" name="puntosJugador"><br>
+                <button type="submit" id="añadir-jugador" class="wpforms" aria-live="assertive">Añadir Nuevo Jugador</button>
+            </form>
+
+            <!-- Formulario para cargar jugadores desde un archivo -->
+            <form id="form-cargar-archivo">
+                <h3>Cargar jugadores desde archivo (.txt)</h3><br>
+                <input type="file" id="archivoJugadores" accept=".txt"><br>
+                <button type="button" id="cargar-archivo" class="wpforms" aria-live="assertive">Cargar Jugadores</button>
+            </form>
+
+            <!-- Formulario para editar jugador existente -->
+            <form id="form-editar-jugador" style="display:none;">
+                <h2>Editar Jugador:</h2>
+                <input type="hidden" id="editJugadorId" name="editJugadorId">
+                <label>Nombre del Jugador</label><input type="text" id="editNombreJugador" name="editNombreJugador" required>
+                <label>Puntos</label><input type="number" step="0.01" id="editPuntosJugador" name="editPuntosJugador" required>
+                <button type="submit" id="guardar-cambios-jugador" class="wpforms" aria-live="assertive">Guardar Cambios</button>
+                <button type="button" id="cancelar-edicion" class="wpforms">Cancelar</button>
+            </form>
+
+            <figure class="wp-block-table is-style-stripes">
+                <table id="tabla-jugadores" class="has-text-color has-link-color" style="color:#1e73be">
+                    <thead>
+                        <tr>
+                            <th class="has-text-align-center" data-align="center">ID</th>
+                            <th class="has-text-align-center" data-align="center">Nombre</th>
+                            <th class="has-text-align-center" data-align="center">Puntos</th>
+                            <th class="has-text-align-center" data-align="center">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+                <figcaption class="wp-element-caption">Tabla de jugadores</figcaption>
+            </figure>
+        </div>
+        <div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:10%"></div>
+    </div>
+</div>
+
+<script>
+var api_url = "https://club-padel-api-12f28391bbbd.herokuapp.com";
+$(document).ready(function(){
+    // Inicializar DataTable con paginado y buscador en español
+    var tablaJugadores = $('#tabla-jugadores').DataTable({
+        language: { url: 'https://cdn.datatables.net/plug-ins/1.13.4/i18n/es-ES.json' }
+    });
+
+    // Función para manejar el envío del formulario de nuevo jugador
+    $('#form-nuevo-jugador').submit(function(event) {
+        event.preventDefault();
+
+        var nombre = $('#nombreJugador').val();
+        var puntos = $('#puntosJugador').val();
+        puntos = puntos ? parseFloat(puntos.replace(',', '.')) : 0;
+
+        $.ajax({
+            url: api_url+'/jugadores',
+            type: 'POST',
+            headers: {
+                'Content-Type' : 'application/json',
+                'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz'
+            },
+            contentType: 'application/json',
+            data: JSON.stringify({ "nombre": nombre, "puntos": puntos }),
+            success: function(data) {
+                $('#nombreJugador').val('');
+                $('#puntosJugador').val('');
+                cargarJugadores();
+            },
+            error: function(xhr, status, error) {
+                console.error('Error al añadir un nuevo jugador:', error);
+            }
+        });
+    });
+
+    // Función para manejar el envío del formulario de edición de jugador
+    $('#form-editar-jugador').submit(function(event) {
+        event.preventDefault();
+
+        var jugadorId = $('#editJugadorId').val();
+        var nombre = $('#editNombreJugador').val();
+        var puntos = $('#editPuntosJugador').val();
+        puntos = puntos ? parseFloat(puntos.replace(',', '.')) : 0;
+
+        $.ajax({
+            url: api_url+'/jugadores/' + jugadorId,
+            type: 'PUT',
+            headers: {
+                'Content-Type' : 'application/json',
+                'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz'
+            },
+            contentType: 'application/json',
+            data: JSON.stringify({ "nombre": nombre, "puntos": puntos }),
+            success: function(data) {
+                cargarJugadores();
+                $('#form-editar-jugador').hide();
+                $('#form-nuevo-jugador').show();
+            },
+            error: function(xhr, status, error) {
+                console.error('Error al actualizar el jugador:', error);
+            }
+        });
+    });
+
+    // Cancelar la edición
+    $('#cancelar-edicion').click(function() {
+        $('#form-editar-jugador').hide();
+        $('#form-nuevo-jugador').show();
+    });
+
+    // Cargar jugadores desde archivo
+    $('#cargar-archivo').click(function() {
+        var file = $('#archivoJugadores')[0].files[0];
+        if(!file){
+            alert('Seleccione un fichero .txt');
+            return;
+        }
+
+        var reader = new FileReader();
+        reader.onload = function(e) {
+            var lines = e.target.result.split(/\r?\n/);
+            var requests = [];
+
+            $.each(lines, function(index, line){
+                if(!line.trim()) return;
+                var parts = line.split('|');
+                if(parts.length < 2) return;
+
+                var nombre = parts[0].trim();
+                var puntosStr = parts[1].trim().replace(',', '.');
+                var puntos = parseFloat(puntosStr);
+                puntos = isNaN(puntos) ? 0 : puntos;
+
+                var request = $.ajax({
+                    url: api_url+'/jugadores',
+                    type: 'POST',
+                    headers: {
+                        'Content-Type' : 'application/json',
+                        'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz'
+                    },
+                    contentType: 'application/json',
+                    data: JSON.stringify({ "nombre": nombre, "puntos": puntos })
+                });
+                requests.push(request);
+            });
+
+            if(requests.length === 0){
+                $('#archivoJugadores').val('');
+                cargarJugadores();
+            }else{
+                $.when.apply($, requests).always(function(){
+                    $('#archivoJugadores').val('');
+                    cargarJugadores();
+                });
+            }
+        };
+
+        reader.readAsText(file);
+    });
+
+    // Función para cargar los jugadores y actualizar la tabla
+    function cargarJugadores() {
+        $.ajax({
+            url: api_url+'/jugadores',
+            type: 'GET',
+            dataType: 'json',
+            headers: {
+                'Content-Type' : 'application/json',
+                'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz'
+            },
+            success: function(data) {
+                tablaJugadores.clear();
+
+                $.each(data, function(index, jugador) {
+                    tablaJugadores.row.add([
+                        jugador.jugadorId,
+                        jugador.nombre,
+                        jugador.puntos,
+                        `<button class="editar-jugador" data-id="${jugador.jugadorId}" data-nombre="${jugador.nombre}" data-puntos="${jugador.puntos}">Editar</button>` +
+                        ` <button class="eliminar-jugador" data-id="${jugador.jugadorId}">Eliminar</button>`
+                    ]);
+                });
+                tablaJugadores.draw();
+            },
+            error: function(xhr, status, error) {
+                console.error('Error al obtener datos de la API:', error);
+            }
+        });
+    }
+
+    // Evento para editar un jugador al hacer clic en el botón "Editar"
+    $('#tabla-jugadores').on('click', '.editar-jugador', function() {
+        var jugadorId = $(this).data('id');
+        var nombre = $(this).data('nombre');
+        var puntos = $(this).data('puntos');
+
+        $('#editJugadorId').val(jugadorId);
+        $('#editNombreJugador').val(nombre);
+        $('#editPuntosJugador').val(puntos);
+
+        $('#form-nuevo-jugador').hide();
+        $('#form-editar-jugador').show();
+    });
+
+    // Evento para eliminar un jugador al hacer clic en el botón "Eliminar"
+    $('#tabla-jugadores').on('click', '.eliminar-jugador', function() {
+        var jugadorId = $(this).data('id');
+
+        $.ajax({
+            url: api_url+'/jugadores/' + jugadorId,
+            type: 'DELETE',
+            headers: {
+                'Content-Type' : 'application/json',
+                'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz'
+            },
+            success: function(data) {
+                cargarJugadores();
+            },
+            error: function(xhr, status, error) {
+                alert('El borrado ha fallado. Contacte con el administrador de la aplicación.');
+                console.error('Error al eliminar el jugador:', error);
+            }
+        });
+    });
+
+    // Cargar jugadores al cargar la página
+    cargarJugadores();
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add jugadoresManagement.html to manage players (add, edit, delete, search)
- allow bulk player creation by uploading a .txt file with `jugador|puntos` per line
- handle decimal separators so player points accept fractional values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f9bc493c8326968213e080b57442