### PR TITLE
Add league management page with classification editing

### DIFF
--- a/ligasManagement.html
+++ b/ligasManagement.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+<title>Gestión de Ligas</title>
+</head>
+<body>
+
+<form id="form-liga" style="margin-bottom:30px;">
+    <h2 id="form-liga-titulo">Añadir Nueva Liga:</h2>
+    <input type="hidden" id="ligaId">
+    <label>Nombre</label>
+    <input type="text" id="ligaNombre" required><br>
+    <label>Fecha Inicio</label>
+    <input type="date" id="ligaInicio" required><br>
+    <label>Fecha Fin</label>
+    <input type="date" id="ligaFin" required><br>
+    <button type="submit" id="btn-guardar-liga">Añadir Liga</button>
+    <button type="button" id="cancelar-edicion-liga" style="display:none;">Cancelar</button>
+</form>
+
+<figure class="wp-block-table is-style-stripes">
+<table id="tabla-ligas" class="has-text-color has-link-color" style="color:#1e73be">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nombre</th>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+</figure>
+
+<div id="clasificacion-section" style="display:none; margin-top:40px;">
+    <h2>Clasificación de Liga: <span id="liga-seleccionada-nombre"></span></h2>
+    <figure class="wp-block-table is-style-stripes">
+    <table id="tabla-clasificacion" class="has-text-color has-link-color" style="color:#1e73be">
+        <thead>
+            <tr>
+                <th>POS</th>
+                <th>PAREJA</th>
+                <th>PJ</th>
+                <th>PG</th>
+                <th>PP</th>
+                <th>PNJ</th>
+                <th>DIF. SET</th>
+                <th>DIF. JG</th>
+                <th>PTS LIGA</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    </figure>
+</div>
+
+<script>
+var api_url = "https://club-padel-api-12f28391bbbd.herokuapp.com";
+var parejas = {};
+var ligaSeleccionada = null;
+
+$(document).ready(function(){
+    var tablaLigas = $('#tabla-ligas').DataTable({
+        language: { url: 'https://cdn.datatables.net/plug-ins/1.13.4/i18n/es-ES.json' }
+    });
+
+    var tablaClasificacion = $('#tabla-clasificacion').DataTable({
+        paging: false,
+        searching: false,
+        info: false,
+        language: { url: 'https://cdn.datatables.net/plug-ins/1.13.4/i18n/es-ES.json' }
+    });
+
+    function cargarParejas(){
+        $.get({
+            url: api_url + '/parejas',
+            headers: { 'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz' },
+            success: function(data){
+                parejas = {};
+                $.each(data, function(i, p){
+                    parejas[p.parejaId] = p.jugador1.nombre + ' - ' + p.jugador2.nombre;
+                });
+            }
+        });
+    }
+
+    function cargarLigas(){
+        $.get({
+            url: api_url + '/ligas',
+            headers: { 'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz' },
+            success: function(data){
+                tablaLigas.clear();
+                $.each(data, function(i, liga){
+                    tablaLigas.row.add([
+                        liga.id,
+                        liga.nombre,
+                        liga.fechaInicio,
+                        liga.fechaFin,
+                        `<button class="editar-liga" data-id="${liga.id}" data-nombre="${liga.nombre}" data-inicio="${liga.fechaInicio}" data-fin="${liga.fechaFin}">Editar</button>
+                         <button class="ver-clasificacion" data-id="${liga.id}" data-nombre="${liga.nombre}">Clasificación</button>`
+                    ]);
+                });
+                tablaLigas.draw();
+            }
+        });
+    }
+
+    function cargarClasificacion(ligaId, nombreLiga){
+        ligaSeleccionada = ligaId;
+        $('#clasificacion-section').show();
+        $('#liga-seleccionada-nombre').text(nombreLiga);
+        $.get({
+            url: api_url + '/clasificaciones',
+            data: { ligaId: ligaId },
+            headers: { 'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz' },
+            success: function(data){
+                tablaClasificacion.clear();
+                $.each(data, function(i, c){
+                    var row = [
+                        `<input type="number" class="clas-input" data-field="pos" value="${c.pos || 0}" data-pareja="${c.parejaId}">`,
+                        parejas[c.parejaId] || c.parejaId,
+                        `<input type="number" class="clas-input" data-field="pj" value="${c.pj || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="pg" value="${c.pg || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="pp" value="${c.pp || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="pnj" value="${c.pnj || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="difSet" value="${c.difSet || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="difJuegos" value="${c.difJuegos || 0}" data-pareja="${c.parejaId}">`,
+                        `<input type="number" class="clas-input" data-field="ptsLiga" value="${c.ptsLiga || 0}" data-pareja="${c.parejaId}">`
+                    ];
+                    tablaClasificacion.row.add(row);
+                });
+                tablaClasificacion.draw();
+            }
+        });
+    }
+
+    $('#form-liga').submit(function(e){
+        e.preventDefault();
+        var id = $('#ligaId').val();
+        var data = {
+            nombre: $('#ligaNombre').val(),
+            fechaInicio: $('#ligaInicio').val(),
+            fechaFin: $('#ligaFin').val()
+        };
+        var method = id ? 'PUT' : 'POST';
+        var url = api_url + '/ligas' + (id ? '/' + id : '');
+        $.ajax({
+            url: url,
+            type: method,
+            headers: { 'Content-Type': 'application/json', 'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz' },
+            data: JSON.stringify(data),
+            success: function(){
+                $('#form-liga')[0].reset();
+                $('#ligaId').val('');
+                $('#form-liga-titulo').text('Añadir Nueva Liga:');
+                $('#btn-guardar-liga').text('Añadir Liga');
+                $('#cancelar-edicion-liga').hide();
+                cargarLigas();
+            }
+        });
+    });
+
+    $('#tabla-ligas tbody').on('click', '.editar-liga', function(){
+        var btn = $(this);
+        $('#ligaId').val(btn.data('id'));
+        $('#ligaNombre').val(btn.data('nombre'));
+        $('#ligaInicio').val(btn.data('inicio'));
+        $('#ligaFin').val(btn.data('fin'));
+        $('#form-liga-titulo').text('Editar Liga:');
+        $('#btn-guardar-liga').text('Guardar Cambios');
+        $('#cancelar-edicion-liga').show();
+        $('html, body').animate({ scrollTop: $("#form-liga").offset().top }, 400);
+    });
+
+    $('#cancelar-edicion-liga').click(function(){
+        $('#form-liga')[0].reset();
+        $('#ligaId').val('');
+        $('#form-liga-titulo').text('Añadir Nueva Liga:');
+        $('#btn-guardar-liga').text('Añadir Liga');
+        $('#cancelar-edicion-liga').hide();
+    });
+
+    $('#tabla-ligas tbody').on('click', '.ver-clasificacion', function(){
+        var ligaId = $(this).data('id');
+        var nombre = $(this).data('nombre');
+        cargarClasificacion(ligaId, nombre);
+    });
+
+    $('#tabla-clasificacion tbody').on('change', '.clas-input', function(){
+        var parejaId = $(this).data('pareja');
+        var fila = $(this).closest('tr');
+        var payload = {
+            id: { ligaId: ligaSeleccionada, parejaId: parejaId },
+            pos: fila.find('input[data-field="pos"]').val(),
+            pj: fila.find('input[data-field="pj"]').val(),
+            pg: fila.find('input[data-field="pg"]').val(),
+            pp: fila.find('input[data-field="pp"]').val(),
+            pnj: fila.find('input[data-field="pnj"]').val(),
+            difSet: fila.find('input[data-field="difSet"]').val(),
+            difJuegos: fila.find('input[data-field="difJuegos"]').val(),
+            ptsLiga: fila.find('input[data-field="ptsLiga"]').val()
+        };
+        $.ajax({
+            url: api_url + '/clasificaciones',
+            type: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': 'Basic Y2x1YnBhZGVsdXNlcjpjbHVicGFkZWxwYXNz' },
+            data: JSON.stringify(payload)
+        });
+    });
+
+    cargarParejas();
+    cargarLigas();
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add liga management page to create and edit leagues
- list existing leagues and show editable classification table

## Testing
- `npx --yes htmlhint ligasManagement.html`

------
https://chatgpt.com/codex/tasks/task_e_689312a2a54c8326ad693312b32518a4