### PR TITLE
Remove deportista role from quota list

### DIFF
--- a/gestionCuotas.html
+++ b/gestionCuotas.html
@@ -98,6 +98,10 @@
                     roleSelect.innerHTML = '<option value="all">Todos</option>';
                     rolesList = [];
                     $.each(data, function(index, rol) {
+                        // Excluir el rol "deportista" de la lista de opciones y de la carga de usuarios
+                        if (rol.nombre && rol.nombre.toLowerCase() === 'deportista') {
+                            return; // Saltar este rol
+                        }
                         rolesList.push(rol.nombre);
                         const option = document.createElement('option');
                         option.value = rol.nombre;


### PR DESCRIPTION
## Summary
- skip loading 'deportista' role in quota management UI to hide it from filters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b81151ccfc83268efc6e0d690c734b