### PR TITLE
fix: tabla de cuotas con cabecera fija

### DIFF
--- a/gestionCuotas.html
+++ b/gestionCuotas.html
@@ -12,6 +12,20 @@
         .not-paid {
             background-color: #f8d7da;
         }
+        .table-container {
+            max-height: 70vh;
+            overflow-y: auto;
+        }
+        #cuotas-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        #cuotas-table thead th {
+            position: sticky;
+            top: 0;
+            background-color: #fff;
+            z-index: 1;
+        }
     </style>
 </head>
 <body>
@@ -42,6 +56,7 @@
         <input type="text" id="user-filter" onkeyup="filterByUser()" placeholder="Buscar por nombre de usuario">
     </div>
 
+    <div class="table-container">
     <table id="cuotas-table" class="has-text-color has-link-color" style="color:#1e73be">
         <thead>
             <tr>
@@ -64,6 +79,7 @@
         <tbody id="cuotas-table-body">
         </tbody>
     </table>
+    </div>
 
     <script>
         var api_url = "https://club-padel-api-12f28391bbbd.herokuapp.com";


### PR DESCRIPTION
## Summary
- mantener la cabecera de la tabla de cuotas visible al hacer scroll

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98a8a6660832684acf96d46d7bd01