### PR TITLE
Use inline refresh icon to reload reservations table

### DIFF
--- a/reservas.html
+++ b/reservas.html
@@ -191,6 +191,9 @@
 <div class="calendar-container">
 <label for="reservation-date">Selecciona una fecha:</label>
 <input id="reservation-date" placeholder="DD/MM/YYYY" type="date"/>
+<svg id="refresh-reservas" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-label="Refrescar tabla" title="Refrescar tabla" style="cursor:pointer;margin-left:8px;">
+  <path d="M17.65 6.35A8 8 0 1 0 20 12h-2a6 6 0 1 1-1.76-4.24l-2.29 2.29H20V4l-2.35 2.35z"/>
+</svg>
 </div>
 <div id="warning-message"></div>
 <center>
@@ -1121,7 +1124,11 @@ function getSelectedPaymentMethod() {
             });
         
             
-        });        
+        });
+
+        document.getElementById('refresh-reservas').addEventListener('click', () => {
+            document.getElementById('reservation-date').dispatchEvent(new Event('change'));
+        });
 
         function cargaPrincipal() {
             //Autoselect today


### PR DESCRIPTION
## Summary
- replace external refresh image with inline SVG for the reservations table refresh control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12bb6ea8083268d715049ec16fa0c